### PR TITLE
__dict_check_dictname requires --no-scope-shadowing to work

### DIFF
--- a/functions/dict.fish
+++ b/functions/dict.fish
@@ -8,7 +8,7 @@ function __dict_usage
     echo "dict contains [-k|--key] [-v|--value] [-i|--index] [DICTNAME] [STRING]"
 end
 
-function __dict_check_dictname -a dictname
+function __dict_check_dictname --no-scope-shadowing -a dictname
     # Check to see that the DICTNAME provided is a valid variable.
     if not set -q -- $dictname
         echo >&2 "dict: Bad DICTNAME. Variable not found: '$dictname'."


### PR DESCRIPTION
I found that __dict_check_dictname was erroring on all `dict set` calls and that it requires --no-scope-shadowing to work in 4.0 and 4.0.1

After this small fix dict.fish works well and improved my program. 