### PR TITLE
Change [] to <> match man page syntax for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ Use `--help` to show usage:
 
     > dict --help
     dict [-h|--help]
-    dict keys [DICTNAME]
-    dict values [DICTNAME]
-    dict get [DICTNAME] [KEY]
-    dict set [DICTNAME] [KEY] [VALUE]
-    dict remove [DICTNAME] [KEY]
-    dict contains [-k|--key] [-v|--value] [-i|--index] [DICTNAME] [STRING]
+    dict keys <DICTNAME>
+    dict values <DICTNAME>
+    dict get <DICTNAME> <KEY>
+    dict set <DICTNAME> <KEY> <VALUE>
+    dict remove <DICTNAME> <KEY>
+    dict contains [-k|--key] [-v|--value] [-i|--index] <DICTNAME> <STRING>
 
 Let's demonstrate how to use a `dict`. We start with a regular Fish array, the only
 difference being that the elements of the array are paired

--- a/functions/dict.fish
+++ b/functions/dict.fish
@@ -1,11 +1,11 @@
 function __dict_usage
     echo "dict [-h|--help]"
-    echo "dict keys [DICTNAME]"
-    echo "dict values [DICTNAME]"
-    echo "dict get [DICTNAME] [KEY]"
-    echo "dict set [DICTNAME] [KEY] [VALUE]"
+    echo "dict keys <DICTNAME>"
+    echo "dict values <DICTNAME>"
+    echo "dict get <DICTNAME> <KEY>"
+    echo "dict set <DICTNAME> <KEY> <VALUE>"
     echo "dict remove [DICTNAME] [KEY]"
-    echo "dict contains [-k|--key] [-v|--value] [-i|--index] [DICTNAME] [STRING]"
+    echo "dict contains [-k|--key] [-v|--value] [-i|--index] <DICTNAME> <STRING>"
 end
 
 function __dict_check_dictname -a dictname


### PR DESCRIPTION
This is a suggestion to change the docs. I was confused originally when reading these as in man pages ( and usage strings typically) a [thing] is optional and that was inconsistent with how dict worked. 